### PR TITLE
feat: generalize QueryReturn

### DIFF
--- a/crates/dwn-rs-stores/src/filters/query.rs
+++ b/crates/dwn-rs-stores/src/filters/query.rs
@@ -6,7 +6,6 @@ use serde_with::{serde_as, DisplayFromStr};
 
 use crate::filters::errors;
 use crate::Filters;
-use dwn_rs_core::Message;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Pagination {
@@ -67,8 +66,8 @@ impl MessageSort {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct QueryReturn {
-    pub messages: Vec<Message>,
+pub struct QueryReturn<T> {
+    pub items: Vec<T>,
     pub cursor: Option<Cursor>,
 }
 

--- a/crates/dwn-rs-stores/src/stores.rs
+++ b/crates/dwn-rs-stores/src/stores.rs
@@ -31,7 +31,7 @@ pub trait MessageStore {
         filter: Filters,
         sort: Option<MessageSort>,
         pagination: Option<Pagination>,
-    ) -> Result<QueryReturn, MessageStoreError>;
+    ) -> Result<QueryReturn<Message>, MessageStoreError>;
 
     async fn delete(&self, tenant: &str, cid: String) -> Result<(), MessageStoreError>;
 

--- a/crates/dwn-rs-stores/src/surrealdb/message_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/message_store.rs
@@ -106,7 +106,7 @@ impl MessageStore for SurrealDB {
         filters: Filters,
         sort: Option<MessageSort>,
         pagination: Option<Pagination>,
-    ) -> Result<QueryReturn, MessageStoreError> {
+    ) -> Result<QueryReturn<Message>, MessageStoreError> {
         let mut qb = SurrealQuery::<GetEncodedMessage>::new(self.db.to_owned());
 
         qb.from(tenant.to_string())
@@ -144,10 +144,7 @@ impl MessageStore for SurrealDB {
             })
             .collect::<Vec<Message>>();
 
-        let qr = QueryReturn {
-            messages: r,
-            cursor,
-        };
+        let qr = QueryReturn { items: r, cursor };
 
         Ok(qr)
     }

--- a/crates/dwn-rs-wasm/src/query.rs
+++ b/crates/dwn-rs-wasm/src/query.rs
@@ -1,7 +1,8 @@
+use dwn_rs_core::Message;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-use dwn_rs_stores::{MessageSort, Pagination, QueryReturn};
+use dwn_rs_stores::{Cursor, MessageSort, Pagination, QueryReturn};
 
 use crate::ser::serializer;
 
@@ -27,9 +28,20 @@ extern "C" {
     pub type JSPagination;
 }
 
-impl From<QueryReturn> for JSQueryReturn {
-    fn from(value: QueryReturn) -> Self {
-        if let Ok(m) = value.serialize(&serializer()) {
+impl From<QueryReturn<Message>> for JSQueryReturn {
+    fn from(value: QueryReturn<Message>) -> Self {
+        #[derive(Serialize)]
+        struct Wrapper<'a> {
+            messages: &'a [Message],
+            cursor: Option<Cursor>,
+        }
+
+        let wrapper = Wrapper {
+            messages: value.items.as_slice(),
+            cursor: value.cursor,
+        };
+
+        if let Ok(m) = wrapper.serialize(&serializer()) {
             return m.into();
         }
 


### PR DESCRIPTION
The Query trait can be used in the EventLog, and the QueryReturn trait can be generalized across serializable T's for events and messages