### PR TITLE
feat: add browser tests using Web Test Runner

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,4 +93,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: make
-          args: test-store-js
+          args: test-store-js-browser

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
 jobs:
   rust-tests:
+    name: Rust tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +33,7 @@ jobs:
           args: --no-workspace workspace-ci-flow
           toolchain: stable
   wasm-tests:
+    name: "WASM (node tests)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -53,6 +55,37 @@ jobs:
         with:
           command: make
           args: build-wasm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - name: Test WASM library against dwn-sdk-js
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: test-store-js
+  browser-tests:
+    name: "WASM (browser tests)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+      - name: Install cargo-make (stable)
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+      - name: Build WASM library
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: build-wasm-browser
       - uses: actions/setup-node@v4
         with:
           node-version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 *.profraw
 RESOLVERCACHE/
 crates/dwn-rs-wasm/node_modules
+crates/dwn-rs-wasm/coverage

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -22,11 +22,31 @@ args = [
 ]
 dependencies = ["install-wasm-pack"]
 
+[tasks.build-wasm-browser]
+workspace = false
+cwd = "crates/dwn-rs-wasm"
+command = "wasm-pack"
+args = [
+  "build",
+  "--target",
+  "web",
+  "--out-name",
+  "index",
+  "--release",
+  "--out-dir",
+  "browsers",
+  "--",
+  "--no-default-features",
+  "--features",
+  "surrealdb-wasm",
+]
+dependencies = ["install-wasm-pack"]
+
 [tasks.install-npm-deps]
 workspace = false
 cwd = "crates/dwn-rs-wasm"
 command = "npm"
-args = ["install"]
+args = ["install", "--include", "dev"]
 
 [tasks.test-store-js]
 workspace = false
@@ -34,6 +54,21 @@ cwd = "crates/dwn-rs-wasm"
 command = "node"
 args = ["node_modules/mocha/bin/mocha.js", "tests/test.js", "--bail", "--exit"]
 dependencies = ["build-wasm", "install-npm-deps"]
+
+
+[tasks.test-store-js-browser]
+workspace = false
+cwd = "crates/dwn-rs-wasm"
+command = "npx"
+args = ["wtr"]
+dependencies = ["build-wasm-browser", "install-npm-deps", "_playwright-install"]
+
+[tasks._playwright-install]
+args = ["playwright", "install"]
+workspace = false
+cwd = "crates/dwn-rs-wasm"
+command = "npx"
+dependencies = ["install-npm-deps"]
 
 [tasks.test-cargo]
 command = "cargo"

--- a/crates/dwn-rs-wasm/package.json
+++ b/crates/dwn-rs-wasm/package.json
@@ -1,19 +1,36 @@
 {
   "name": "dwn-rs-wasm",
-  "version": "0.0.1",
+  "version": "0.1.0-dev",
   "type": "module",
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.18"
+    "@tbd54566975/dwn-sdk-js": "0.2.18",
+    "@types/readable-stream": "4.0.10",
+    "readable-stream": "4.5.2"
   },
   "devDependencies": {
+    "@rollup/plugin-alias": "^5.1.0",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-inject": "^5.0.5",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^5.0.5",
+    "@rollup/plugin-wasm": "^6.2.2",
     "@types/mocha": "^10.0.1",
+    "@web/dev-server-rollup": "^0.6.1",
+    "@web/test-runner": "^0.18.1",
+    "@web/test-runner-playwright": "^0.11.0",
     "chai": "^4.3.8",
     "chai-as-promised": "^7.1.1",
     "fake-indexeddb": "^4.0.2",
     "isomorphic-ws": "^5.0.0",
     "mocha": "^10.2.0",
+    "node-stdlib-browser": "^1.2.0",
     "sinon": "^15.2.0",
+    "text-encoding": "^0.7.0",
     "ts-sinon": "^2.0.2",
     "typescript": "^5.2.2"
+  },
+  "scripts": {
+    "wtr": "npx wtr --config ./web-test-runner.config.mjs"
   }
 }

--- a/crates/dwn-rs-wasm/tests/test.browser.js
+++ b/crates/dwn-rs-wasm/tests/test.browser.js
@@ -1,0 +1,25 @@
+import { TestSuite } from "@tbd54566975/dwn-sdk-js/tests";
+import init, {
+  SurrealDataStore,
+  SurrealMessageStore,
+  SurrealEventLog,
+} from "../browsers/index.js";
+import stores from "../browsers/index_bg.wasm";
+
+let instance = await stores();
+await init(instance);
+
+let s = new SurrealMessageStore();
+// await s.connect("ws://192.168.10.56:8000/");
+await s.connect("mem://");
+let d = new SurrealDataStore();
+await d.connect("mem://");
+let e = new SurrealEventLog();
+await e.connect("mem://");
+describe("Store dependent tests", () => {
+  TestSuite.runStoreDependentTests({
+    messageStore: s,
+    dataStore: d,
+    eventLog: e,
+  });
+});

--- a/crates/dwn-rs-wasm/web-test-runner.config.mjs
+++ b/crates/dwn-rs-wasm/web-test-runner.config.mjs
@@ -18,7 +18,6 @@ export default {
   browsers: [
     playwrightLauncher({ product: "chromium" }),
     playwrightLauncher({ product: "firefox" }),
-    playwrightLauncher({ product: "webkit" }),
   ],
   nodeResolve: true,
   testFramework: "mocha",

--- a/crates/dwn-rs-wasm/web-test-runner.config.mjs
+++ b/crates/dwn-rs-wasm/web-test-runner.config.mjs
@@ -1,0 +1,54 @@
+import { rollupBundlePlugin } from "@web/dev-server-rollup";
+
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import alias from "@rollup/plugin-alias";
+import inject from "@rollup/plugin-inject";
+import replace from "@rollup/plugin-replace";
+import wasm from "@rollup/plugin-wasm";
+import { playwrightLauncher } from "@web/test-runner-playwright";
+
+import stdLibBrowser from "node-stdlib-browser";
+
+export default {
+  rootDir: "./",
+  files: "./tests/test.browser.js",
+  coverage: true,
+  browsers: [
+    playwrightLauncher({ product: "chromium" }),
+    playwrightLauncher({ product: "firefox" }),
+    playwrightLauncher({ product: "webkit" }),
+  ],
+  nodeResolve: true,
+  testFramework: "mocha",
+  plugins: [
+    rollupBundlePlugin({
+      rollupConfig: {
+        input: ["tests/test.browser.js"],
+        plugins: [
+          replace({
+            include: ["tests/*.js"],
+            __environment__: '"development"',
+          }),
+          alias({
+            entries: stdLibBrowser,
+          }),
+          resolve({
+            browser: true,
+          }),
+          commonjs(),
+          wasm({
+            include: ["browsers/*.wasm"],
+            maxFileSize: 25600000,
+          }),
+          json(),
+          inject({
+            process: stdLibBrowser.process,
+            Buffer: [stdLibBrowser.buffer, "Buffer"],
+          }),
+        ],
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Add browser tests to test the WASM integration with dwn-sdk-js to ensure the code is portable to Node and Browser environments