### PR TITLE
feat: threadsafe streams in WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
+ "serde_bytes",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/dwn-rs-stores/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/data_store.rs
@@ -1,6 +1,6 @@
 use async_stream::stream;
 use async_trait::async_trait;
-use futures_util::{Stream, StreamExt};
+use futures_util::{pin_mut, Stream, StreamExt};
 use surrealdb::sql::{Id, Table, Thing};
 
 use crate::{
@@ -25,11 +25,13 @@ impl DataStore for SurrealDB {
         tenant: &str,
         record_id: String,
         cid: String,
-        mut value: T,
+        value: T,
     ) -> Result<PutDataResults, DataStoreError>
     where
         T: Stream<Item = Vec<u8>> + Unpin + Send,
     {
+        pin_mut!(value);
+
         let id = Thing::from((
             Table::from(tenant.to_string()).to_string(),
             Id::String(cid.to_string()),

--- a/crates/dwn-rs-wasm/Cargo.toml
+++ b/crates/dwn-rs-wasm/Cargo.toml
@@ -43,3 +43,4 @@ dwn-rs-core = { path = "../dwn-rs-core" }
 dwn-rs-stores = { path = "../dwn-rs-stores", default-features = false }
 
 wasm-streams = "0.4.0"
+serde_bytes = "0.11.14"

--- a/crates/dwn-rs-wasm/src/surrealdb/message_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/message_store.rs
@@ -1,4 +1,3 @@
-use dwn_rs_core::MapValue;
 use dwn_rs_stores::{surrealdb::SurrealDB, MessageStore};
 use js_sys::Reflect;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
This commit adds thread safety to streams coming from JavaScript environments, like NodeJS or Browsers.