### PR TITLE
chore: cleanup from_stream

### DIFF
--- a/crates/dwn-rs-wasm/src/streams/stream.rs
+++ b/crates/dwn-rs-wasm/src/streams/stream.rs
@@ -3,7 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::{pin_mut, Future, StreamExt};
+use futures_util::{pin_mut, StreamExt};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio_stream::Stream;
 use wasm_bindgen::prelude::*;

--- a/crates/dwn-rs-wasm/src/streams/stream.rs
+++ b/crates/dwn-rs-wasm/src/streams/stream.rs
@@ -3,7 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{pin_mut, Future, StreamExt};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio_stream::Stream;
 use wasm_bindgen::prelude::*;
@@ -104,14 +104,14 @@ impl IntoStream {
         let (done_tx, done_rx) = unbounded_channel::<()>();
 
         let data_cb = Closure::wrap(Box::new(move |d| {
-            let val = serde_wasm_bindgen::from_value(d).unwrap();
-            data_tx.send(val).unwrap();
+            let val = serde_wasm_bindgen::from_value(d).unwrap_throw();
+            data_tx.send(val).unwrap_throw();
         }) as Box<dyn FnMut(JsValue)>)
         .into_js_value();
         readable.on("data", data_cb.as_ref().unchecked_ref());
 
         let end_cb = Closure::wrap(Box::new(move || {
-            done_tx.send(()).unwrap();
+            done_tx.send(()).unwrap_throw();
         }) as Box<dyn FnMut()>)
         .into_js_value();
         readable.on("end", end_cb.as_ref().unchecked_ref());

--- a/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
@@ -112,10 +112,10 @@ impl SurrealDataStore {
         let size = v.size;
         let reader = stream! {
             while let Some(chunk) = v.data.next().await {
-                yield Ok(serde_bytes::ByteBuf::from(chunk))
+                yield Some(serde_bytes::ByteBuf::from(chunk))
             }
 
-            yield Err(JsValue::NULL);
+            yield None;
         };
 
         let obj: DataStoreGetResult = JsCast::unchecked_into(Object::new());
@@ -123,7 +123,7 @@ impl SurrealDataStore {
         Reflect::set(
             &obj,
             &"dataStream".into(),
-            StreamReadable::from_stream(reader).await.as_raw(),
+            StreamReadable::from_stream(reader).await?.as_raw(),
         )?;
 
         Ok(Some(obj))


### PR DESCRIPTION
Clean up pinning on the from_stream to avoid potential races, throw in JS on error, simplify logic