### PR TITLE
feat: update tenancy model for surrealdb store implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "ulid",
+ "url",
 ]
 
 [[package]]
@@ -4170,6 +4171,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/crates/dwn-rs-stores/Cargo.toml
+++ b/crates/dwn-rs-stores/Cargo.toml
@@ -53,3 +53,4 @@ surrealdb = { version = "1.4.2", default-features = false, optional = true, feat
 
 dwn-rs-core = { path = "../dwn-rs-core" }
 ulid = { version = "1.1.2", features = ["serde"] }
+url = { version = "2.5.0", features = ["serde"] }

--- a/crates/dwn-rs-stores/src/errors.rs
+++ b/crates/dwn-rs-stores/src/errors.rs
@@ -43,10 +43,10 @@ pub enum MessageStoreError {
     #[error("failed to decode cid")]
     CidDecodeError(#[source] ipld_core::cid::Error),
 
-    #[error("unable to perform query")]
+    #[error("unable to perform query: {0}")]
     QueryError(#[from] QueryError),
 
-    #[error("unable to create filters")]
+    #[error("unable to create filters: {0}")]
     FilterError(#[from] FilterError),
 }
 

--- a/crates/dwn-rs-stores/src/surrealdb/auth.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/auth.rs
@@ -1,0 +1,190 @@
+use serde::Serialize;
+use surrealdb::{
+    iam::Level,
+    opt::auth::{self, Credentials},
+};
+use thiserror::Error;
+
+#[derive(Serialize, Clone, Debug)]
+pub struct Auth {
+    #[serde(rename = "user", skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(rename = "pass", skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(rename = "ns")]
+    pub namespace: String,
+    pub level: Level,
+}
+impl PartialEq for Auth {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.level.clone(), other.level.clone()) {
+            (Level::No, Level::No) => self.namespace == other.namespace,
+            (Level::Root, Level::Root) => {
+                self.username == other.username
+                    && self.password == other.password
+                    && self.namespace == other.namespace
+            }
+            (Level::Namespace(sns), Level::Namespace(ons)) => {
+                self.username == other.username
+                    && self.password == other.password
+                    && self.namespace == other.namespace
+                    && self.namespace == sns
+                    && self.namespace == ons
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Auth {
+    // has auth returns true if authenticaiton material (username/password)
+    // exists
+    pub fn has_auth(&self) -> bool {
+        matches!(
+            self,
+            Auth {
+                username: Some(_),
+                password: Some(_),
+                ..
+            }
+        )
+    }
+
+    pub fn ns(&self) -> &str {
+        self.namespace.as_str()
+    }
+
+    // parse the connection string for authentication information that can be used to sign in. The
+    // connection string, with credentials, is expected to be in the format:
+    //
+    //   `<proto>://<username>:<password>@<host>:<port>/<namespace>?auth=[root|namespace]`
+    //
+    // for Namespace-based authentication.
+    //
+    // Returns the connection string and the credentials.
+    pub(crate) fn parse_connstr(connstr: &str) -> Result<(String, Option<Self>), AuthError> {
+        let connstr = connstr.trim();
+        let parts = url::Url::parse(connstr)?;
+
+        if parts.scheme().is_empty() {
+            return Err(AuthError::InvalidConnStr(url::ParseError::EmptyHost));
+        }
+
+        let namespace = parts.path().trim_start_matches('/');
+
+        let mut auth = Auth {
+            username: None,
+            password: None,
+            namespace: namespace.to_string(),
+            level: Level::No,
+        };
+
+        if parts.has_authority() && parts.password().is_some() {
+            auth.username = Some(parts.username().to_owned());
+            auth.password = Some(parts.password().unwrap_or_default().to_owned());
+            auth.level = Level::Root;
+        }
+
+        // auth type is defined by the query parameter
+        if let Some((_, v)) = parts.query_pairs().find(|(k, _)| k == "auth") {
+            match v.as_ref() {
+                "root" => {
+                    auth.level = Level::Root;
+                }
+                "namespace" => {
+                    auth.level = Level::Namespace(namespace.to_string());
+                }
+                _ => {
+                    return Err(AuthError::InvalidAuthInfo(v.to_string()));
+                }
+            }
+        };
+
+        let connstr = format!(
+            "{}://{}",
+            parts.scheme(),
+            match parts.host() {
+                Some(host) => {
+                    if let Some(port) = parts.port() {
+                        format!("{}:{}", host, port)
+                    } else {
+                        host.to_string()
+                    }
+                }
+                None => "".to_string(), // e.g. memory:// of file:// will not have a proper host
+            },
+        );
+        Ok((connstr, Some(auth)))
+    }
+}
+
+impl Credentials<auth::Signin, auth::Jwt> for Auth {}
+
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("invalid connection string: {0}")]
+    InvalidConnStr(#[from] url::ParseError),
+
+    #[error("invalid authentication information: {0}")]
+    InvalidAuthInfo(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_connstr() {
+        let connstr = "mem:///ns";
+        let (connstr, creds) = Auth::parse_connstr(connstr).expect("parseable");
+        assert_eq!(connstr, "mem://");
+        assert_eq!(
+            creds,
+            Some(Auth {
+                username: None,
+                password: None,
+                namespace: "ns".to_string(),
+                level: Level::No,
+            })
+        );
+
+        let connstr = "http://user:pass@localhost:8080/ns";
+        let (connstr, creds) = Auth::parse_connstr(connstr).expect("parseable");
+        assert_eq!(connstr, "http://localhost:8080");
+        assert_eq!(
+            creds,
+            Some(Auth {
+                username: Some("user".to_string()),
+                password: Some("pass".to_string()),
+                namespace: "ns".to_string(),
+                level: Level::Root,
+            })
+        );
+
+        let connstr = "http://user:password@localhost:8080/ns?auth=root";
+        let (connstr, creds) = Auth::parse_connstr(connstr).expect("parsable");
+        assert_eq!(connstr, "http://localhost:8080");
+        assert_eq!(
+            creds,
+            Some(Auth {
+                username: Some("user".to_string()),
+                password: Some("password".to_string()),
+                namespace: "ns".to_string(),
+                level: Level::Root,
+            })
+        );
+
+        let connstr = "http://user:password@localhost:8080/ns?auth=namespace";
+        let (connstr, creds) = Auth::parse_connstr(connstr).expect("parsable");
+        assert_eq!(connstr, "http://localhost:8080");
+        assert_eq!(
+            creds,
+            Some(Auth {
+                username: Some("user".to_string()),
+                password: Some("password".to_string()),
+                namespace: "ns".to_string(),
+                level: Level::Namespace("ns".to_string()),
+            })
+        );
+    }
+}

--- a/crates/dwn-rs-stores/src/surrealdb/core.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/core.rs
@@ -1,43 +1,21 @@
 use std::sync::Arc;
 
-use serde::Serialize;
 use surrealdb::{
     engine::any::Any,
-    opt::auth::{self, Credentials},
+    iam::Level,
+    opt::auth::{self},
     Surreal,
 };
 use ulid::Generator;
 
-use crate::StoreError;
+use crate::{surrealdb::auth::Auth, StoreError};
 
 use super::errors::SurrealDBError;
 
-const NAMESPACE: &str = "dwn";
-
-// Database is a enum of databases that can be used with SurrealDB stores
-#[derive(Debug, Clone, Copy)]
-pub enum Database {
-    None,
-    Messages,
-    Data,
-    Events,
-}
-
-impl From<Database> for String {
-    fn from(db: Database) -> Self {
-        match db {
-            Database::None => "".into(),
-            Database::Messages => "messages".into(),
-            Database::Data => "data".into(),
-            Database::Events => "events".into(),
-        }
-    }
-}
-
 pub struct SurrealDB {
     pub(super) db: Arc<Surreal<Any>>,
-    pub(super) db_name: Database,
-    pub(super) _constr: String,
+    constr: String,
+    invalid: bool,
 
     pub(super) ulid_generator: Generator,
 }
@@ -48,18 +26,17 @@ impl Default for SurrealDB {
     }
 }
 
+const META_DB: &str = "_meta";
+
 impl SurrealDB {
     pub(super) async fn open(&mut self) -> Result<(), StoreError> {
         let health = self.db.health().await;
-        if health.is_err() {
-            if self._constr.is_empty() {
+        if health.is_err() || self.invalid {
+            if self.constr.is_empty() {
                 return Err(StoreError::NoInitError);
             } else {
-                let connstr = self._constr.clone();
-                self.db
-                    .connect(&connstr)
-                    .await
-                    .map_err(SurrealDBError::from)?;
+                let connstr = self.constr.clone();
+                self.connect(&connstr).await.map_err(SurrealDBError::from)?;
             }
         }
 
@@ -68,13 +45,14 @@ impl SurrealDB {
 
     pub(super) async fn close(&mut self) {
         let _ = self.db.invalidate().await;
+        self.invalid = true;
     }
 
     pub fn new() -> Self {
         Self {
             db: Arc::new(surrealdb::Surreal::init()),
-            db_name: Database::None,
-            _constr: String::new(),
+            constr: String::new(),
+            invalid: false,
 
             ulid_generator: Generator::new(),
         }
@@ -85,31 +63,48 @@ impl SurrealDB {
         self
     }
 
-    pub async fn connect(
-        &mut self,
-        connstr: &str,
-        db_name: Database,
-    ) -> Result<(), SurrealDBError> {
-        self.db_name = db_name;
-        self._constr = connstr.into();
-        let (connstr, auth) = parse_connstr(connstr);
-        self.db.connect(connstr).await?;
-        if let Some(auth) = auth {
-            self.db
-                .signin(auth)
-                .await
-                .map_err(Into::<SurrealDBError>::into)?;
+    pub async fn connect(&mut self, connstr: &str) -> Result<(), SurrealDBError> {
+        self.constr = connstr.into();
+        let (connstr, auth) = Auth::parse_connstr(connstr)?;
+
+        if !self.invalid {
+            self.db.connect(connstr.clone()).await?;
         }
+
+        if let Some(auth) = auth {
+            if auth.has_auth() {
+                match auth.level {
+                    Level::Root => {
+                        self.db
+                            .signin(auth::Root {
+                                username: auth.username.as_ref().unwrap().as_str(),
+                                password: auth.password.as_ref().unwrap().as_str(),
+                            })
+                            .await
+                            .map_err(Into::<SurrealDBError>::into)?;
+                    }
+                    Level::Namespace(_) => {
+                        self.db
+                            .signin(auth::Namespace {
+                                username: auth.username.as_ref().unwrap().as_str(),
+                                password: auth.password.as_ref().unwrap().as_str(),
+                                namespace: auth.namespace.as_str(),
+                            })
+                            .await
+                            .map_err(Into::<SurrealDBError>::into)?;
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            self.db.use_ns(auth.ns()).await?;
+        }
+
+        self.db.use_db(META_DB).await?;
         self.db
             .health()
             .await
             .map_err(Into::<SurrealDBError>::into)?;
-        self.db
-            .use_ns(NAMESPACE)
-            .use_db(self.db_name)
-            .await
-            .map_err(Into::into)
-    }
 
     pub(super) async fn clear(&self) -> Result<(), StoreError> {
         self.db
@@ -125,129 +120,11 @@ impl SurrealDB {
     }
 }
 
-#[derive(Serialize, Clone, Debug)]
-#[serde(untagged)]
-enum Auth<'a> {
-    Root(auth::Root<'a>),
-    Namespace(auth::Namespace<'a>),
-    Database(auth::Database<'a>),
-}
 
-impl PartialEq for Auth<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Auth::Root(a), Auth::Root(b)) => a.username == b.username && a.password == b.password,
-            (Auth::Namespace(a), Auth::Namespace(b)) => {
-                Auth::Root(auth::Root {
-                    username: a.username,
-                    password: a.password,
-                }) == Auth::Root(auth::Root {
-                    username: b.username,
-                    password: b.password,
-                }) && a.namespace == b.namespace
-            }
-            (Auth::Database(a), Auth::Database(b)) => {
-                Auth::Namespace(auth::Namespace {
-                    username: a.username,
-                    password: a.password,
-                    namespace: a.namespace,
-                }) == Auth::Namespace(auth::Namespace {
-                    username: b.username,
-                    password: b.password,
-                    namespace: b.namespace,
-                }) && a.database == b.database
-            }
-            _ => false,
         }
     }
 }
 
-impl<'a> Credentials<auth::Signin, auth::Jwt> for Auth<'a> {}
 
-// parse the connection string for authentication information that can be used to sign in. The
-// connection string, with credentials, is expected to be in the format:
-//   `<proto>://<username>:<password>@<host>:<port>/<database>?ns=<namespace>&scope=<scope>`
-// Returns the connection string and the credentials.
-fn parse_connstr(connstr: &str) -> (String, Option<Auth>) {
-    let connstr = connstr.trim();
-    let (proto, connstr) = connstr.split_once("://").unwrap_or_default();
-    let (auth, connstr) = connstr.split_once('@').unwrap_or(("", connstr));
-    let (username, password) = auth.split_once(':').unwrap_or(("", ""));
-    let (connstr, db) = connstr.split_once('/').unwrap_or((connstr, ""));
-    let (db, ns) = db.split_once("?ns=").unwrap_or(("", ""));
-
-    let connstr = format!("{}://{}", proto, connstr);
-
-    let creds = match (
-        username.is_empty(),
-        password.is_empty(),
-        db.is_empty(),
-        ns.is_empty(),
-    ) {
-        (true, _, _, _) | (_, true, _, _) => None,
-        (_, _, true, true) => Some(Auth::Root(auth::Root { username, password })),
-        (_, _, false, false) => Some(Auth::Database(auth::Database {
-            database: db,
-            username,
-            password,
-            namespace: ns,
-        })),
-        (_, _, _, false) => Some(Auth::Namespace(auth::Namespace {
-            namespace: ns,
-            username,
-            password,
-        })),
-        _ => None,
-    };
-
-    (connstr, creds)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_connstr() {
-        let connstr = "http://user:pass@localhost:8080/db?ns=ns";
-        let (connstr, creds) = parse_connstr(connstr);
-        assert_eq!(connstr, "http://localhost:8080");
-        assert_eq!(
-            creds,
-            Some(Auth::Database(auth::Database {
-                database: "db",
-                username: "user",
-                password: "pass",
-                namespace: "ns"
-            }))
-        );
-
-        let connstr = "http://user:pass@localhost:8080/?ns=ns";
-        let (connstr, creds) = parse_connstr(connstr);
-        assert_eq!(connstr, "http://localhost:8080");
-        assert_eq!(
-            creds,
-            Some(Auth::Namespace(auth::Namespace {
-                username: "user",
-                password: "pass",
-                namespace: "ns"
-            }))
-        );
-
-        let connstr = "http://localhost:8080";
-        let (connstr, creds) = parse_connstr(connstr);
-        assert_eq!(connstr, "http://localhost:8080");
-        assert_eq!(creds, None);
-
-        let connstr = "http://user:password@localhost:8080";
-        let (connstr, creds) = parse_connstr(connstr);
-        assert_eq!(connstr, "http://localhost:8080");
-        assert_eq!(
-            creds,
-            Some(Auth::Root(auth::Root {
-                username: "user",
-                password: "password",
-            }))
-        );
     }
 }

--- a/crates/dwn-rs-stores/src/surrealdb/errors.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/errors.rs
@@ -1,4 +1,4 @@
-use crate::{QueryError, StoreError, ValueError};
+use crate::{surrealdb::auth::AuthError, QueryError, StoreError, ValueError};
 
 use thiserror::Error;
 
@@ -9,6 +9,12 @@ pub enum SurrealDBError {
 
     #[error("Surreal error: {0}")]
     SurrealError(#[from] surrealdb::Error),
+
+    #[error("no namespace provided")]
+    NoNamespace,
+
+    #[error("authentication error: {0}")]
+    AuthError(#[from] AuthError),
 }
 
 impl From<SurrealDBError> for QueryError {
@@ -28,6 +34,8 @@ impl From<SurrealDBError> for StoreError {
         match e {
             SurrealDBError::DBError(e) => Self::InternalException(e.to_string()),
             SurrealDBError::SurrealError(e) => Self::InternalException(e.to_string()),
+            SurrealDBError::NoNamespace => Self::InternalException(e.to_string()),
+            SurrealDBError::AuthError(e) => Self::InternalException(e.to_string()),
         }
     }
 }

--- a/crates/dwn-rs-stores/src/surrealdb/event_log.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/event_log.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use dwn_rs_core::MapValue;
-use surrealdb::sql::{Id, Range, Table, Thing};
+use surrealdb::sql::{Id, Table, Thing};
 
 use crate::{
     Cursor, EventLog, EventLogError, Filters, MessageCidSort, Pagination, Query, QueryReturn,
@@ -8,8 +8,6 @@ use crate::{
 };
 
 use super::models::{CreateEvent, GetEvent};
-
-trait IntoRange: Into<Range> + Sized {}
 
 const EVENTS_TABLE: &str = "events";
 

--- a/crates/dwn-rs-stores/src/surrealdb/mod.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/mod.rs
@@ -1,3 +1,4 @@
+mod auth;
 pub mod core;
 pub mod data_store;
 pub mod errors;

--- a/crates/dwn-rs-stores/src/surrealdb/query.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/query.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::ops::Bound;
-use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use dwn_rs_core::MapValue;
@@ -27,7 +27,7 @@ where
 {
     binds: MapValue,
 
-    db: Arc<surrealdb::Surreal<Any>>,
+    db: surrealdb::Surreal<Any>,
 
     stmt: SelectStatement,
     from: String,
@@ -44,7 +44,7 @@ where
     U: DeserializeOwned,
     T: Directional + Default + Ordorable + Sync + Copy,
 {
-    pub fn new(db: Arc<surrealdb::Surreal<Any>>) -> Self {
+    pub fn new(db: surrealdb::Surreal<Any>) -> Self {
         Self {
             db,
             binds: MapValue::new(),

--- a/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 use dwn_rs_stores::{
-    surrealdb::{Database, SurrealDB, SurrealDBError},
+    surrealdb::{SurrealDB, SurrealDBError},
     DataStore, DataStoreError,
 };
 
@@ -54,7 +54,7 @@ impl SurrealDataStore {
     #[wasm_bindgen]
     pub async fn connect(&mut self, connstr: &str) -> Result<(), JsValue> {
         self.store
-            .connect(connstr, Database::Data)
+            .connect(connstr)
             .await
             .map_err(SurrealDataStoreError::from)
             .map_err(Into::into)

--- a/crates/dwn-rs-wasm/src/surrealdb/event_log.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/event_log.rs
@@ -1,6 +1,5 @@
 use dwn_rs_stores::{
-    surrealdb::{Database, SurrealDB},
-    Cursor, EventLog, EventLogError, QueryReturn, StoreError, SurrealDBError,
+    surrealdb::SurrealDB, Cursor, EventLog, EventLogError, QueryReturn, StoreError, SurrealDBError,
 };
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
@@ -41,7 +40,7 @@ impl SurrealEventLog {
     #[wasm_bindgen]
     pub async fn connect(&mut self, connstr: &str) -> Result<(), JsError> {
         self.store
-            .connect(connstr, Database::Events)
+            .connect(connstr)
             .await
             .map_err(SurrealDBError::from)
             .map_err(Into::into)

--- a/crates/dwn-rs-wasm/src/surrealdb/message_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/message_store.rs
@@ -38,7 +38,7 @@ impl SurrealMessageStore {
     #[wasm_bindgen]
     pub async fn connect(&mut self, connstr: &str) -> Result<(), JsValue> {
         self.store
-            .connect(connstr, dwn_rs_stores::surrealdb::Database::Messages)
+            .connect(connstr)
             .await
             .map_err(Into::<JsError>::into)
             .map_err(Into::into)


### PR DESCRIPTION
- Use databases as a tenancy model in SurrealDB, since there is no limit to the maximum number of databases
- Provide namespace-based authentication, and root-based authentication that requires full namespace ownership to provide tenancy
- Provide schemaless tables within tenant databases for messages, data, events.