### PR TITLE
chore: remove use of async-trait for Rust 1.75.0+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,6 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 name = "dwn-rs-core"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "base64 0.22.1",
  "chrono",
  "cid",
@@ -1369,7 +1368,6 @@ name = "dwn-rs-stores"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "chrono",
  "cid",
  "dwn-rs-core",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-dwn-rs
-====
+# dwn-rs
 
 dwn-rs is a Rust-based DWN implementation that can be
 used with [dwn-sdk-js](https://github.com/TBD54566975/dwn-sdk-js).
 
 # Compiling
+
+## Requirements
+
+- Rust 1.75.0+
 
 This project uses [cargo-make](https://sagiegurari.github.io/cargo-make/). To
 install it, run:

--- a/crates/dwn-rs-core/Cargo.toml
+++ b/crates/dwn-rs-core/Cargo.toml
@@ -9,7 +9,6 @@ description = "Core library components for dwn-rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1.73"
 chrono = { version = "0.4.30", features = ["serde"] }
 cid = { version = "0.11.1", features = ["serde"] }
 futures-util = "0.3.30"

--- a/crates/dwn-rs-core/src/filters/query.rs
+++ b/crates/dwn-rs-core/src/filters/query.rs
@@ -1,5 +1,6 @@
+use std::future::Future;
+
 use crate::value::Value;
-use async_trait::async_trait;
 use ipld_core::cid::Cid;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -159,7 +160,6 @@ pub struct QueryReturn<T> {
 }
 
 // Trait for implementing Filters
-#[async_trait]
 pub trait Query<U, T>
 where
     U: DeserializeOwned,
@@ -172,5 +172,7 @@ where
     fn page(&mut self, pagination: Option<Pagination>) -> &mut Self;
     fn always_cursor(&mut self) -> &mut Self;
     fn sort(&mut self, sort: Option<T>) -> &mut Self;
-    async fn query(&self) -> Result<(Vec<U>, Option<crate::Cursor>), errors::QueryError>;
+    fn query(
+        &self,
+    ) -> impl Future<Output = Result<(Vec<U>, Option<crate::Cursor>), errors::QueryError>> + Send;
 }

--- a/crates/dwn-rs-core/src/stores.rs
+++ b/crates/dwn-rs-core/src/stores.rs
@@ -166,5 +166,3 @@ pub trait ResumableTaskStore: Default {
 
     fn clear(&self) -> impl Future<Output = Result<(), ResumableTaskStoreError>> + Send;
 }
-
-}

--- a/crates/dwn-rs-stores/Cargo.toml
+++ b/crates/dwn-rs-stores/Cargo.toml
@@ -22,7 +22,6 @@ surreal-wasm = ["surrealdb", "surrealdb/kv-indxdb"]
 
 [dependencies]
 async-stream = "0.3.5"
-async-trait = "0.1.73"
 futures-util = "0.3.30"
 chrono = { version = "0.4.37", features = ["serde", "wasmbind"] }
 cid = { version = "0.11.1", features = ["serde"] }

--- a/crates/dwn-rs-stores/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/data_store.rs
@@ -1,5 +1,4 @@
 use async_stream::stream;
-use async_trait::async_trait;
 use futures_util::{pin_mut, Stream, StreamExt};
 use surrealdb::sql::{Id, Table, Thing};
 
@@ -13,7 +12,6 @@ use super::models::{CreateData, GetData};
 
 const DATA_TABLE: &str = "data";
 
-#[async_trait]
 impl DataStore for SurrealDB {
     async fn open(&mut self) -> Result<(), DataStoreError> {
         self.open().await.map_err(DataStoreError::from)

--- a/crates/dwn-rs-stores/src/surrealdb/event_log.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/event_log.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use surrealdb::sql::{Id, Table, Thing};
 
 use crate::{SurrealDB, SurrealDBError, SurrealQuery};
@@ -13,7 +12,6 @@ use super::models::{CreateEvent, GetEvent};
 
 const EVENTS_TABLE: &str = "events";
 
-#[async_trait]
 impl EventLog for SurrealDB {
     async fn open(&mut self) -> Result<(), EventLogError> {
         self.open().await.map_err(EventLogError::from)

--- a/crates/dwn-rs-stores/src/surrealdb/message_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/message_store.rs
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 
-use async_trait::async_trait;
 use cid::Cid;
 use multihash_codetable::{Code, MultihashDigest};
 use surrealdb::sql::{Id, Thing};
@@ -23,7 +22,6 @@ use super::{
 
 const MESSAGES_TABLE: &str = "messages";
 
-#[async_trait]
 impl MessageStore for SurrealDB {
     async fn open(&mut self) -> Result<(), MessageStoreError> {
         self.open().await.map_err(MessageStoreError::from)

--- a/crates/dwn-rs-stores/src/surrealdb/query.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/query.rs
@@ -4,7 +4,6 @@ use std::{
     ops::{Bound, RangeBounds},
 };
 
-use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use surrealdb::sql::{value as surreal_value, Cond, Function, Idiom, Subquery};
 use surrealdb::{
@@ -69,7 +68,6 @@ pub trait CursorValue<T> {
     fn cursor_value(&self, sort: T) -> dwn_rs_core::value::Value;
 }
 
-#[async_trait]
 impl<U, T> Query<U, T> for SurrealQuery<U, T>
 where
     U: CursorValue<T> + DeserializeOwned + Sync + Send + Debug,

--- a/crates/dwn-rs-stores/src/surrealdb/resumable_task_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/resumable_task_store.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 use surrealdb::sql::{
@@ -22,7 +21,6 @@ const RESUMABLE_TASKS_DB: &str = "tasks";
 const RESUMABLE_TASKS_TABLE: &str = "resumable_tasks";
 const TASK_TIMEOUT: u64 = 60;
 
-#[async_trait]
 impl ResumableTaskStore for SurrealDB {
     async fn open(&mut self) -> Result<(), ResumableTaskStoreError> {
         self.db = self.db.clone();


### PR DESCRIPTION
With Rust 1.75.0+, -> impl Trait (including -> impl Future) is supported for Traits, allowing for async trait definitions without the async-trait crate.

Remove use of the async-trait crate, and use Rust's 1.75.0+ features.

https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html