### PR TITLE
feat: add Protocol tests, no_std on wasm crate, lower memory requirements for JS streaming

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,29 @@ jobs:
           command: make
           args: --no-workspace workspace-ci-flow
           toolchain: stable
+  wasm-build:
+    name: "WASM (Node build)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+      - name: Install cargo-make (stable)
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+      - name: Build WASM library
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: build-wasm-no-opt
   wasm-tests:
     name: "WASM (node tests)"
     runs-on: ubuntu-latest
@@ -52,11 +75,6 @@ jobs:
         with:
           command: install
           args: --debug cargo-make
-      - name: Build WASM library
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: build-wasm
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
@@ -65,8 +83,8 @@ jobs:
         with:
           command: make
           args: test-store-js
-  browser-tests:
-    name: "WASM (browser tests)"
+  browser-build:
+    name: "WASM (browser build)"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +105,25 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: make
-          args: build-wasm-browser
+          args: build-wasm-browser-no-opt
+  browser-tests:
+    name: "WASM (browser tests)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+      - name: Install cargo-make (stable)
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,28 +324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,7 +1352,7 @@ dependencies = [
 name = "dwn-rs-stores"
 version = "0.1.0"
 dependencies = [
- "async-stream",
+ "async-std",
  "chrono",
  "cid",
  "dwn-rs-core",
@@ -1391,7 +1369,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-stream",
+ "tracing",
  "ulid",
  "url",
 ]
@@ -1400,7 +1378,7 @@ dependencies = [
 name = "dwn-rs-wasm"
 version = "0.2.1"
 dependencies = [
- "async-stream",
+ "async-std",
  "console_error_panic_hook",
  "dwn-rs-core",
  "dwn-rs-stores",
@@ -6044,17 +6022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,20 +1404,18 @@ dependencies = [
  "console_error_panic_hook",
  "dwn-rs-core",
  "dwn-rs-stores",
+ "futures-channel",
+ "futures-core",
  "futures-util",
  "js-sys",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_bytes",
- "thiserror",
- "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "tracing-subscriber-wasm",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -2607,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -6484,19 +6482,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -6509,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6521,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6531,9 +6530,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6544,9 +6543,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,24 @@ args = [
 ]
 dependencies = ["install-wasm-pack"]
 
+[tasks.build-wasm-no-opt]
+workspace = false
+cwd = "crates/dwn-rs-wasm"
+command = "wasm-pack"
+args = [
+    "build",
+    "--no-opt",
+    "--target",
+    "nodejs",
+    "--out-name",
+    "index",
+    "--",
+    "--no-default-features",
+    "--features",
+    "surrealdb-wasm",
+]
+dependencies = ["install-wasm-pack"]
+
 [tasks.build-wasm-browser]
 workspace = false
 cwd = "crates/dwn-rs-wasm"
@@ -40,6 +58,26 @@ args = [
 ]
 dependencies = ["install-wasm-pack"]
 
+[tasks.build-wasm-browser-no-opt]
+workspace = false
+cwd = "crates/dwn-rs-wasm"
+command = "wasm-pack"
+args = [
+    "build",
+    "--no-opt",
+    "--target",
+    "web",
+    "--out-name",
+    "index",
+    "--out-dir",
+    "browsers",
+    "--",
+    "--no-default-features",
+    "--features",
+    "surrealdb-wasm",
+]
+
+dependencies = ["install-wasm-pack"]
 [tasks.install-npm-deps]
 workspace = false
 cwd = "crates/dwn-rs-wasm"
@@ -51,7 +89,7 @@ workspace = false
 cwd = "crates/dwn-rs-wasm"
 command = "node"
 args = ["node_modules/mocha/bin/mocha.js", "tests/test.js", "--bail", "--exit"]
-dependencies = ["build-wasm", "install-npm-deps"]
+dependencies = ["build-wasm-no-opt", "install-npm-deps"]
 
 
 [tasks.test-store-js-browser]
@@ -59,7 +97,11 @@ workspace = false
 cwd = "crates/dwn-rs-wasm"
 command = "npx"
 args = ["wtr"]
-dependencies = ["build-wasm-browser", "install-npm-deps", "_playwright-install"]
+dependencies = [
+    "build-wasm-browser-no-opt",
+    "install-npm-deps",
+    "_playwright-install",
+]
 
 [tasks._playwright-install]
 args = ["playwright", "install", "--with-deps"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,6 +18,8 @@ args = [
     "--no-default-features",
     "--features",
     "surrealdb-wasm",
+    "--features",
+    "no-std",
 ]
 dependencies = ["install-wasm-pack"]
 
@@ -36,6 +38,8 @@ args = [
     "--no-default-features",
     "--features",
     "surrealdb-wasm",
+    "--features",
+    "no-std",
 ]
 dependencies = ["install-wasm-pack"]
 
@@ -55,6 +59,8 @@ args = [
     "--no-default-features",
     "--features",
     "surrealdb-wasm",
+    "--features",
+    "no-std",
 ]
 dependencies = ["install-wasm-pack"]
 
@@ -75,6 +81,8 @@ args = [
     "--no-default-features",
     "--features",
     "surrealdb-wasm",
+    "--features",
+    "no-std",
 ]
 
 dependencies = ["install-wasm-pack"]

--- a/crates/dwn-rs-core/src/interfaces/messages/descriptors/messages.rs
+++ b/crates/dwn-rs-core/src/interfaces/messages/descriptors/messages.rs
@@ -41,13 +41,21 @@ pub struct SubscribeDescriptor {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use super::*;
-    use chrono::Utc;
+    use chrono::{DateTime, SecondsFormat, Utc};
     use serde_json::json;
 
     #[test]
     fn test_read_descriptor() {
-        let message_timestamp = Utc::now();
+        let message_timestamp = DateTime::from_str(
+            Utc::now()
+                .to_rfc3339_opts(SecondsFormat::Micros, true)
+                .as_str(),
+        )
+        .unwrap();
+
         // new random DagCbor encoded CID
         let message_cid = Cid::new_v1(0x71, cid::multihash::Multihash::default());
         let descriptor = ReadDescriptor {
@@ -67,7 +75,13 @@ mod test {
 
     #[test]
     fn test_query_descriptor() {
-        let message_timestamp = Utc::now();
+        let message_timestamp = DateTime::from_str(
+            Utc::now()
+                .to_rfc3339_opts(SecondsFormat::Micros, true)
+                .as_str(),
+        )
+        .unwrap();
+
         let filters = vec![crate::Filters::default()];
         let cursor = Some(crate::Cursor::default());
         let descriptor = QueryDescriptor {
@@ -89,14 +103,20 @@ mod test {
 
     #[test]
     fn test_subscribe_descriptor() {
-        let message_timestamp = Utc::now();
+        let message_timestamp = DateTime::from_str(
+            Utc::now()
+                .to_rfc3339_opts(SecondsFormat::Micros, true)
+                .as_str(),
+        )
+        .unwrap();
+
         let filters = vec![crate::Filters::default()];
         let descriptor = SubscribeDescriptor {
             message_timestamp,
             filters,
         };
         let json = json!({
-            "messageTimestamp": &message_timestamp,
+            "messageTimestamp": message_timestamp,
             "filters": [crate::Filters::default()],
         });
         assert_eq!(serde_json::to_value(&descriptor).unwrap(), json);

--- a/crates/dwn-rs-core/src/interfaces/messages/descriptors/protocols.rs
+++ b/crates/dwn-rs-core/src/interfaces/messages/descriptors/protocols.rs
@@ -29,7 +29,7 @@ pub struct ProtocolType {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq, Clone)]
 pub struct ProtocolRule {
     #[serde(rename = "$encryption")]
     pub encryption: Option<Encryption>,
@@ -230,4 +230,158 @@ pub struct QueryDescriptor {
 pub struct QueryFilter {
     pub protocol: Option<String>,
     pub recipient: Option<DIDBuf>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+
+    #[test]
+    fn test_configure_descriptor() {
+        let message_timestamp = Utc::now();
+        let definition = ProtocolDefinition {
+            protocol: "example".to_string(),
+            published: true,
+            types: BTreeMap::new(),
+            structure: BTreeMap::new(),
+        };
+        let descriptor = ConfigureDescriptor {
+            message_timestamp,
+            definition,
+        };
+        let json = json!({
+            "messageTimestamp": message_timestamp,
+            "definition": {
+                "protocol": "example",
+                "published": true,
+                "types": {},
+                "structure": {},
+            },
+        });
+        assert_eq!(serde_json::to_value(&descriptor).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<ConfigureDescriptor>(json).unwrap(),
+            descriptor
+        );
+    }
+
+    #[test]
+    fn test_protocol_definition() {
+        let protocol = "example".to_string();
+        let published = true;
+        let types = BTreeMap::new();
+        let structure = BTreeMap::new();
+        let definition = ProtocolDefinition {
+            protocol: protocol.clone(),
+            published,
+            types,
+            structure,
+        };
+        let json = json!({
+            "protocol": protocol,
+            "published": published,
+            "types": {},
+            "structure": {},
+        });
+        assert_eq!(serde_json::to_value(&definition).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<ProtocolDefinition>(json).unwrap(),
+            definition
+        );
+    }
+
+    #[test]
+    fn test_protocol_type() {
+        let schema = Some("schema".to_string());
+        let data_formats = Some(vec!["format".to_string()]);
+        let protocol_type = ProtocolType {
+            schema: schema.clone(),
+            data_formats: data_formats.clone(),
+        };
+        let json = json!({
+            "schema": schema,
+            "dataFormats": data_formats,
+        });
+        assert_eq!(serde_json::to_value(&protocol_type).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<ProtocolType>(json).unwrap(),
+            protocol_type
+        );
+    }
+
+    #[test]
+    fn test_protocol_rule() {
+        let encryption = Some(Encryption {
+            root_key_id: "root".to_string(),
+            public_key_jwk: JWK::generate_ed25519().unwrap(),
+        });
+        let actions = vec![Action::Who {
+            who: Who::Anyone,
+            of: None,
+            can: vec![Can::Read],
+        }];
+
+        let role = Some(true);
+        let size = Some(Size {
+            min: None,
+            max: None,
+        });
+        let tags = Some(Tags {
+            required_tags: vec!["tag".to_string()],
+            allow_undefined_tags: Some(true),
+            tags: BTreeMap::new(),
+        });
+
+        let extra = BTreeMap::new();
+        let protocol_rule = ProtocolRule {
+            encryption: encryption.clone(),
+            actions: actions.clone(),
+            role,
+            size: size.clone(),
+            tags: tags.clone(),
+            extra,
+        };
+
+        let json = json!({
+            "$encryption": encryption.clone(),
+            "$actions": actions,
+            "$role": role,
+            "$size": size,
+            "$tags": tags,
+        });
+
+        assert_eq!(serde_json::to_value(&protocol_rule).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<ProtocolRule>(json).unwrap(),
+            protocol_rule
+        );
+
+        let json = json!({
+            "$encryption": encryption,
+            "$actions": actions,
+            "$role": role,
+            "$size": size,
+            "$tags": tags,
+            "key": {},
+        });
+
+        let mut extra = BTreeMap::new();
+        extra.insert("key".to_string(), ProtocolRule::default());
+        let protocol_rule = ProtocolRule {
+            encryption,
+            actions,
+            role,
+            size,
+            tags,
+            extra,
+        };
+
+        assert_eq!(serde_json::to_value(&protocol_rule).unwrap(), json);
+        assert_eq!(
+            serde_json::from_value::<ProtocolRule>(json).unwrap(),
+            protocol_rule
+        );
+    }
 }

--- a/crates/dwn-rs-core/src/stores.rs
+++ b/crates/dwn-rs-core/src/stores.rs
@@ -28,7 +28,7 @@ pub trait MessageStore: Default {
     fn get(
         &self,
         tenant: &str,
-        cid: String,
+        cid: &str,
     ) -> impl Future<Output = Result<Message, MessageStoreError>> + Send;
 
     fn query(
@@ -42,7 +42,7 @@ pub trait MessageStore: Default {
     fn delete(
         &self,
         tenant: &str,
-        cid: String,
+        cid: &str,
     ) -> impl Future<Output = Result<(), MessageStoreError>> + Send;
 
     fn clear(&self) -> impl Future<Output = Result<(), MessageStoreError>> + Send;
@@ -56,23 +56,23 @@ pub trait DataStore: Default {
     fn put<T: Stream<Item = Vec<u8>> + Send + Unpin>(
         &self,
         tenant: &str,
-        record_id: String,
-        cid: String,
+        record_id: &str,
+        cid: &str,
         value: T,
     ) -> impl Future<Output = Result<PutDataResults, DataStoreError>> + Send;
 
     fn get(
         &self,
         tenant: &str,
-        record_id: String,
-        cid: String,
+        record_id: &str,
+        cid: &str,
     ) -> impl Future<Output = Result<GetDataResults, DataStoreError>> + Send;
 
     fn delete(
         &self,
         tenant: &str,
-        record_id: String,
-        cid: String,
+        record_id: &str,
+        cid: &str,
     ) -> impl Future<Output = Result<(), DataStoreError>> + Send;
 
     fn clear(&self) -> impl Future<Output = Result<(), DataStoreError>> + Send;
@@ -97,7 +97,7 @@ pub trait EventLog: Default {
     fn append(
         &self,
         tenant: &str,
-        cid: String,
+        cid: &str,
         indexes: MapValue,
         tags: MapValue,
     ) -> impl Future<Output = Result<(), EventLogError>>;
@@ -150,18 +150,18 @@ pub trait ResumableTaskStore: Default {
 
     fn read<T: Serialize + Send + Sync + DeserializeOwned + Debug>(
         &self,
-        task_id: String,
+        task_id: &str,
     ) -> impl Future<Output = Result<Option<ManagedResumableTask<T>>, ResumableTaskStoreError>> + Send;
 
     fn extend(
         &self,
-        task_id: String,
+        task_id: &str,
         timeout: u64,
     ) -> impl Future<Output = Result<(), ResumableTaskStoreError>> + Send;
 
     fn delete(
         &self,
-        task_id: String,
+        task_id: &str,
     ) -> impl Future<Output = Result<(), ResumableTaskStoreError>> + Send;
 
     fn clear(&self) -> impl Future<Output = Result<(), ResumableTaskStoreError>> + Send;

--- a/crates/dwn-rs-core/src/stores.rs
+++ b/crates/dwn-rs-core/src/stores.rs
@@ -53,7 +53,7 @@ pub trait DataStore: Default {
 
     fn close(&mut self) -> impl Future<Output = ()> + Send;
 
-    fn put<T: Stream<Item = Vec<u8>> + Send + Unpin>(
+    fn put<T: Stream<Item = u8> + Send + Unpin>(
         &self,
         tenant: &str,
         record_id: &str,
@@ -86,7 +86,7 @@ pub struct PutDataResults {
 
 pub struct GetDataResults {
     pub size: usize,
-    pub data: Pin<Box<dyn Stream<Item = Vec<u8>>>>,
+    pub data: Pin<Box<dyn Stream<Item = u8>>>,
 }
 
 pub trait EventLog: Default {

--- a/crates/dwn-rs-stores/Cargo.toml
+++ b/crates/dwn-rs-stores/Cargo.toml
@@ -21,7 +21,6 @@ surreal-wasm = ["surrealdb", "surrealdb/kv-indxdb"]
 
 
 [dependencies]
-async-stream = "0.3.5"
 futures-util = "0.3.30"
 chrono = { version = "0.4.37", features = ["serde", "wasmbind"] }
 cid = { version = "0.11.1", features = ["serde"] }
@@ -32,8 +31,6 @@ multihash-codetable = { version = "0.1.2", features = ["serde", "sha2"] }
 thiserror = "1.0.63"
 time = "0.3.36"
 tokio = { version = "1.39.2", features = ["io-util", "rt", "macros"] }
-tokio-stream = { version = "0.1.14", default-features = false, features = [
-    "io-util",
 ] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_ipld_dagcbor = "0.6.0"
@@ -47,3 +44,4 @@ url = { version = "2.5.0", features = ["serde"] }
 
 dwn-rs-core = { path = "../dwn-rs-core", default-features = false }
 serde_json = "1.0.122"
+async-std = { version = "1.12.0", default-features = false, features = ["async-global-executor", "async-io", "futures-lite", "kv-log-macro", "pin-project-lite"] }

--- a/crates/dwn-rs-stores/Cargo.toml
+++ b/crates/dwn-rs-stores/Cargo.toml
@@ -31,6 +31,8 @@ multihash-codetable = { version = "0.1.2", features = ["serde", "sha2"] }
 thiserror = "1.0.63"
 time = "0.3.36"
 tokio = { version = "1.39.2", features = ["io-util", "rt", "macros"] }
+tracing = { version = "0.1.40", default-features = false, features = [
+    "attributes",
 ] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_ipld_dagcbor = "0.6.0"

--- a/crates/dwn-rs-stores/Cargo.toml
+++ b/crates/dwn-rs-stores/Cargo.toml
@@ -18,6 +18,7 @@ surrealdb = [
 ]
 surreal-lib = ["surrealdb", "surrealdb/kv-speedb"]
 surreal-wasm = ["surrealdb", "surrealdb/kv-indxdb"]
+no-std = []
 
 
 [dependencies]

--- a/crates/dwn-rs-stores/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/data_store.rs
@@ -24,8 +24,8 @@ impl DataStore for SurrealDB {
     async fn put<T>(
         &self,
         tenant: &str,
-        record_id: String,
-        cid: String,
+        record_id: &str,
+        cid: &str,
         value: T,
     ) -> Result<PutDataResults, DataStoreError>
     where
@@ -80,8 +80,8 @@ impl DataStore for SurrealDB {
     async fn get(
         &self,
         tenant: &str,
-        record_id: String,
-        _: String,
+        record_id: &str,
+        _: &str,
     ) -> Result<GetDataResults, DataStoreError> {
         let id = Thing::from((DATA_TABLE, Id::String(record_id.to_string())));
 
@@ -111,12 +111,7 @@ impl DataStore for SurrealDB {
         })
     }
 
-    async fn delete(
-        &self,
-        tenant: &str,
-        record_id: String,
-        _: String,
-    ) -> Result<(), DataStoreError> {
+    async fn delete(&self, tenant: &str, record_id: &str, _: &str) -> Result<(), DataStoreError> {
         let id = Thing::from((DATA_TABLE, Id::String(record_id.to_string())));
 
         self.with_database(tenant, |db| async move {

--- a/crates/dwn-rs-stores/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/data_store.rs
@@ -1,7 +1,14 @@
+use async_std::stream::{self, from_iter};
 use futures_util::{pin_mut, Stream, StreamExt};
-use surrealdb::sql::{Id, Table, Thing};
+use surrealdb::sql::{
+    statements::RelateStatement, Data, Id, Ident, Idiom, Operator, Param, Table, Thing, Value,
+};
+use tracing::Instrument;
 
-use crate::{SurrealDB, SurrealDBError};
+use crate::{
+    surrealdb::models::{DataChunk, DataChunkSize},
+    SurrealDB, SurrealDBError,
+};
 use dwn_rs_core::{
     errors::{DataStoreError, StoreError},
     stores::{DataStore, GetDataResults, PutDataResults},
@@ -10,6 +17,8 @@ use dwn_rs_core::{
 use super::models::{CreateData, GetData};
 
 const DATA_TABLE: &str = "data";
+const CHUNK_TABLE: &str = "data_chunks";
+const CHUNK_CAPACITY: usize = 1024 * 1024;
 
 impl DataStore for SurrealDB {
     async fn open(&mut self) -> Result<(), DataStoreError> {
@@ -28,9 +37,10 @@ impl DataStore for SurrealDB {
         value: T,
     ) -> Result<PutDataResults, DataStoreError>
     where
-        T: Stream<Item = Vec<u8>> + Unpin + Send,
+        T: Stream<Item = u8> + Unpin + Send,
     {
-        pin_mut!(value);
+        let chunks = value.chunks(CHUNK_CAPACITY);
+        pin_mut!(chunks);
 
         let id = Thing::from((DATA_TABLE, Id::String(record_id.to_string())));
 
@@ -44,7 +54,6 @@ impl DataStore for SurrealDB {
                 db.create::<Option<GetData>>(id.clone())
                     .content(CreateData {
                         cid: cid.to_string(),
-                        data: Vec::new(),
                         tenant: tenant.to_string(),
                         record_id: record_id.to_string(),
                     })
@@ -52,22 +61,52 @@ impl DataStore for SurrealDB {
                     .map_err(SurrealDBError::from)
                     .map_err(StoreError::from)?;
 
+                let mut offset = 0;
                 let mut len = 0;
-                while let Some(chunk) = value.next().await {
+                while let Some(chunk) = chunks.next().await {
                     let u = db
-                        .update::<Option<GetData>>(id.clone())
-                        .merge(CreateData {
-                            cid: cid.to_string(),
-                            data: chunk,
-                            tenant: tenant.to_string(),
-                            record_id: record_id.to_string(),
+                        .create::<Vec<DataChunk>>(CHUNK_TABLE)
+                        .content(DataChunk {
+                            id: None,
+                            data: chunk.clone(),
                         })
                         .await
                         .map_err(SurrealDBError::from)
                         .map_err(StoreError::from)?;
 
-                    len += u.unwrap().data.len();
+                    let mut relate = RelateStatement::default();
+                    relate.from = Value::Param(Param::from(Ident::from("chunk")));
+                    relate.kind = Value::Table(Table::from("data_for"));
+                    relate.with = Value::Param(Param::from(Ident::from("data")));
+                    relate.data = Some(Data::SetExpression(vec![(
+                        Idiom::from("offset"),
+                        Operator::Equal,
+                        Value::Param(Param::from("offset")),
+                    )]));
+                    relate.only = true;
+
+                    tracing::trace!(relate = relate.to_string(), chunk = chunk.len());
+
+                    db.query(relate)
+                        .bind(("chunk", u[0].id.clone().unwrap()))
+                        .bind(("data", id.clone()))
+                        .bind(("offset", offset))
+                        .await
+                        .map_err(SurrealDBError::from)
+                        .map_err(StoreError::from)?;
+
+                    offset += 1;
+                    len += u[0].data.len();
                 }
+
+                db.update::<Option<DataChunkSize>>(id.clone())
+                    .merge(DataChunkSize {
+                        length: Some(len),
+                        chunks: Some(offset),
+                    })
+                    .await
+                    .map_err(SurrealDBError::from)
+                    .map_err(StoreError::from)?;
 
                 Ok(len)
             })
@@ -84,14 +123,51 @@ impl DataStore for SurrealDB {
     ) -> Result<GetDataResults, DataStoreError> {
         let id = Thing::from((DATA_TABLE, Id::String(record_id.to_string())));
 
-        let res: GetData = self
+        let (res, s) = self
             .with_database(tenant, |db| async move {
-                db.select(id)
+                let d = db
+                    .select::<Option<GetData>>(id.clone())
                     .await
                     .map_err(SurrealDBError::from)
-                    .map_err(StoreError::from)
-                    .expect("failed to fetch from database")
-                    .ok_or(StoreError::NotFound)
+                    .map_err(StoreError::from)?
+                    .ok_or(StoreError::NotFound)?;
+
+                let chunks = d.chunks.ok_or(StoreError::NotFound)?;
+                tracing::trace!(chunks, d = ?d, "fetching chunks for data");
+
+                let i = from_iter(0..chunks)
+                    .flat_map(move |offset| {
+                        let db = db.clone();
+                        let id = id.clone();
+
+                        futures_util::stream::once(
+                            async move {
+                                tracing::trace!(?id, "fetching data");
+
+                                db
+                                    .query(
+                                        "
+                                SELECT
+                                    <->(data_for WHERE offset = $offset)<->data_chunks.data AS chunks
+                                FROM ONLY $from
+                            ",
+                                    )
+                                    .bind(("from", id.clone()))
+                                    .bind(("offset", offset))
+                                    .await
+                                    .expect("failed to bind")
+                                    // .map_err(SurrealDBError::from)
+                                    // .map_err(StoreError::from)?;
+                                    .take::<Vec<Vec<u8>>>((0, "chunks"))
+                                    .expect("failed to take 0")
+                            }
+                            .instrument(tracing::trace_span!("fetching data", offset)),
+                        )
+                    })
+                    .flat_map(|r| stream::from_iter(r.into_iter().flatten()));
+
+
+                Ok((d, i))
             })
             .await?;
 
@@ -99,8 +175,7 @@ impl DataStore for SurrealDB {
             return Err(DataStoreError::StoreError(StoreError::NotFound));
         }
 
-        let size = res.data.len();
-        let s = async_std::stream::from_iter(vec![res.data].into_iter());
+        let size = res.length.ok_or(StoreError::NotFound)?;
 
         Ok(GetDataResults {
             size,
@@ -124,6 +199,10 @@ impl DataStore for SurrealDB {
 
     async fn clear(&self) -> Result<(), DataStoreError> {
         self.clear(&Table::from(DATA_TABLE))
+            .await
+            .map_err(DataStoreError::from)?;
+
+        self.clear(&Table::from(CHUNK_TABLE))
             .await
             .map_err(DataStoreError::from)
     }

--- a/crates/dwn-rs-stores/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/data_store.rs
@@ -1,4 +1,3 @@
-use async_stream::stream;
 use futures_util::{pin_mut, Stream, StreamExt};
 use surrealdb::sql::{Id, Table, Thing};
 
@@ -101,9 +100,7 @@ impl DataStore for SurrealDB {
         }
 
         let size = res.data.len();
-        let s = stream! {
-            yield res.data;
-        };
+        let s = async_std::stream::from_iter(vec![res.data].into_iter());
 
         Ok(GetDataResults {
             size,

--- a/crates/dwn-rs-stores/src/surrealdb/event_log.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/event_log.rs
@@ -24,7 +24,7 @@ impl EventLog for SurrealDB {
     async fn append(
         &self,
         tenant: &str,
-        cid: String,
+        cid: &str,
         indexes: MapValue,
         tags: MapValue,
     ) -> Result<(), EventLogError> {
@@ -36,7 +36,7 @@ impl EventLog for SurrealDB {
             db.create::<Option<CreateEvent>>(res)
                 .content(CreateEvent {
                     watermark,
-                    cid,
+                    cid: cid.to_string(),
                     indexes,
                     tags,
                 })

--- a/crates/dwn-rs-stores/src/surrealdb/message_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/message_store.rs
@@ -70,7 +70,7 @@ impl MessageStore for SurrealDB {
         Ok(cid)
     }
 
-    async fn get(&self, tenant: &str, cid: String) -> Result<Message, MessageStoreError> {
+    async fn get(&self, tenant: &str, cid: &str) -> Result<Message, MessageStoreError> {
         // fetch and decode the message from the db
         let encoded_message: GetEncodedMessage = self
             .with_database(tenant, |db| async move {
@@ -156,7 +156,7 @@ impl MessageStore for SurrealDB {
         Ok(QueryReturn { items: r, cursor })
     }
 
-    async fn delete(&self, tenant: &str, cid: String) -> Result<(), MessageStoreError> {
+    async fn delete(&self, tenant: &str, cid: &str) -> Result<(), MessageStoreError> {
         let id = Thing::from((MESSAGES_TABLE, Id::String(cid.to_string())));
 
         // check the tenancy on the messages

--- a/crates/dwn-rs-stores/src/surrealdb/models.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/models.rs
@@ -52,7 +52,6 @@ impl CursorValue<MessageSort> for GetEncodedMessage {
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct CreateData {
     pub(super) cid: String,
-    pub(super) data: Vec<u8>,
     pub(super) tenant: String,
     pub(super) record_id: String,
 }
@@ -61,9 +60,23 @@ pub(crate) struct CreateData {
 pub(crate) struct GetData {
     pub(super) id: Thing,
     pub(super) cid: String,
-    pub(super) data: Vec<u8>,
     pub(super) tenant: String,
     pub(super) record_id: String,
+    pub(super) chunks: Option<usize>,
+    pub(super) length: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct DataChunkSize {
+    pub(super) length: Option<usize>,
+    pub(super) chunks: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct DataChunk {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) id: Option<Thing>,
+    pub(super) data: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/dwn-rs-stores/src/surrealdb/resumable_task_store.rs
+++ b/crates/dwn-rs-stores/src/surrealdb/resumable_task_store.rs
@@ -156,7 +156,7 @@ impl ResumableTaskStore for SurrealDB {
 
     async fn read<T: Serialize + Send + Sync + DeserializeOwned + Debug>(
         &self,
-        task_id: String,
+        task_id: &str,
     ) -> Result<Option<ManagedResumableTask<T>>, ResumableTaskStoreError> {
         match self
             .db
@@ -175,7 +175,7 @@ impl ResumableTaskStore for SurrealDB {
         }
     }
 
-    async fn extend(&self, task_id: String, timeout: u64) -> Result<(), ResumableTaskStoreError> {
+    async fn extend(&self, task_id: &str, timeout: u64) -> Result<(), ResumableTaskStoreError> {
         let timeout = timeout_expr(timeout);
         self.db
             .update::<Option<ExtendedTask>>((RESUMABLE_TASKS_TABLE, task_id))
@@ -187,7 +187,7 @@ impl ResumableTaskStore for SurrealDB {
         Ok(())
     }
 
-    async fn delete(&self, task_id: String) -> Result<(), ResumableTaskStoreError> {
+    async fn delete(&self, task_id: &str) -> Result<(), ResumableTaskStoreError> {
         self.db
             .delete::<Option<ExtendedTask>>((RESUMABLE_TASKS_TABLE, task_id))
             .await

--- a/crates/dwn-rs-wasm/Cargo.toml
+++ b/crates/dwn-rs-wasm/Cargo.toml
@@ -19,7 +19,6 @@ no-std = []
 wasm-opt = true
 
 [dependencies]
-async-stream = "0.3.5"
 console_error_panic_hook = "0.1.7"
 futures-util = { version = "0.3.30", default-features = false, features = [
     "alloc",
@@ -69,4 +68,13 @@ futures-core = { version = "0.3.30", default-features = false, features = [
 ] }
 
 dwn-rs-core = { path = "../dwn-rs-core", default-features = false }
-dwn-rs-stores = { path = "../dwn-rs-stores", default-features = false }
+dwn-rs-stores = { path = "../dwn-rs-stores", default-features = false, features = [
+    "no-std",
+] }
+async-std = { version = "1.12.0", default-features = false, features = [
+    "async-global-executor",
+    "async-io",
+    "futures-lite",
+    "kv-log-macro",
+    "pin-project-lite",
+] }

--- a/crates/dwn-rs-wasm/Cargo.toml
+++ b/crates/dwn-rs-wasm/Cargo.toml
@@ -13,6 +13,7 @@ default = ["surrealdb-lib"]
 surrealdb = []
 surrealdb-lib = ["surrealdb", "dwn-rs-stores/surreal-lib"]
 surrealdb-wasm = ["surrealdb", "dwn-rs-stores/surreal-wasm"]
+no-std = []
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true
@@ -20,15 +21,19 @@ wasm-opt = true
 [dependencies]
 async-stream = "0.3.5"
 console_error_panic_hook = "0.1.7"
-futures-util = "0.3.30"
-js-sys = "0.3.64"
-serde = { version = "1.0.183", features = ["derive"] }
+futures-util = { version = "0.3.30", default-features = false, features = [
+    "alloc",
+    "async-await",
+    "async-await-macro",
+] }
+js-sys = "0.3.70"
+serde = { version = "1.0.183", default-fatures = false, features = [
+    "derive",
+    "alloc",
+] }
 serde-wasm-bindgen = "0.6.3"
-thiserror = "1.0.47"
-wasm-bindgen = { version = "0.2.91", features = ["enable-interning"] }
-tokio = { version = "1.39.2", features = ["io-util", "rt", "macros"] }
-tokio-stream = { version = "0.1.14", default-features = false, features = [
-    "io-util",
+wasm-bindgen = { version = "0.2.93", default-features = false, features = [
+    "spans",
 ] }
 wasm-bindgen-futures = "0.4.37"
 web-sys = { version = "0.3.64", features = [
@@ -39,11 +44,29 @@ web-sys = { version = "0.3.64", features = [
     "ReadableStream",
 ] }
 
+serde_bytes = { version = "0.11.14", default-features = false, features = [
+    "alloc",
+] }
+tracing = { version = "0.1.40", default-features = false, features = [
+    "attributes",
+] }
+tracing-subscriber-wasm = "0.1.0"
+tracing-subscriber = { version = "0.3.18", default-features = false, features = [
+    "ansi",
+    "fmt",
+    "smallvec",
+    "tracing-log",
+    "chrono",
+    "json",
+    "serde",
+    "serde_json",
+] }
+futures-channel = { version = "0.3.30", default-features = false, features = [
+    "alloc",
+] }
+futures-core = { version = "0.3.30", default-features = false, features = [
+    "alloc",
+] }
+
 dwn-rs-core = { path = "../dwn-rs-core", default-features = false }
 dwn-rs-stores = { path = "../dwn-rs-stores", default-features = false }
-
-wasm-streams = "0.4.0"
-serde_bytes = "0.11.14"
-tracing = "0.1.40"
-tracing-subscriber-wasm = "0.1.0"
-tracing-subscriber = { version = "0.3.18", features = ["chrono", "json", "serde", "serde_json"] }

--- a/crates/dwn-rs-wasm/src/filter.rs
+++ b/crates/dwn-rs-wasm/src/filter.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use wasm_bindgen::prelude::*;
 
 use dwn_rs_core::{

--- a/crates/dwn-rs-wasm/src/lib.rs
+++ b/crates/dwn-rs-wasm/src/lib.rs
@@ -1,3 +1,10 @@
+#![cfg_attr(feature = "no-std", no_std)]
+
+#[cfg(feature = "no-std")]
+extern crate alloc;
+#[cfg(not(feature = "no-std"))]
+extern crate std as alloc;
+
 mod data;
 mod filter;
 mod message;

--- a/crates/dwn-rs-wasm/src/message.rs
+++ b/crates/dwn-rs-wasm/src/message.rs
@@ -1,3 +1,4 @@
+use alloc::{format, vec, vec::Vec};
 use serde::Serialize;
 use wasm_bindgen::{prelude::*, throw_str};
 

--- a/crates/dwn-rs-wasm/src/message.rs
+++ b/crates/dwn-rs-wasm/src/message.rs
@@ -1,4 +1,4 @@
-use alloc::{format, vec, vec::Vec};
+use alloc::vec::Vec;
 use serde::Serialize;
 use wasm_bindgen::{prelude::*, throw_str};
 
@@ -24,37 +24,30 @@ impl From<&GenericMessage> for Message {
             throw_str("Message is undefined");
         }
 
-        match serde_wasm_bindgen::from_value(value.into()) {
-            Ok(m) => m,
-            Err(e) => throw_str(&format!("unable to deserialize message: {:?}", e)),
-        }
+        serde_wasm_bindgen::from_value(value.into()).expect_throw("unable to deserialize message")
     }
 }
 
 impl From<Message> for GenericMessage {
     fn from(value: Message) -> Self {
-        match value.serialize(&serializer()) {
-            Ok(m) => m.into(),
-            Err(e) => throw_str(&format!("unable to serialize message: {:?}", e)),
-        }
+        value
+            .serialize(&serializer())
+            .expect_throw("unable to serialize message")
+            .into()
     }
 }
 
 impl From<&GenericMessageArray> for Vec<Message> {
     fn from(value: &GenericMessageArray) -> Self {
-        if let Ok(m) = serde_wasm_bindgen::from_value(value.into()) {
-            return m;
-        }
-
-        vec![]
+        serde_wasm_bindgen::from_value(value.into()).expect_throw("unable to deserialize messages")
     }
 }
 
 impl From<Vec<Message>> for GenericMessageArray {
     fn from(value: Vec<Message>) -> Self {
-        match value.serialize(&serializer()) {
-            Ok(m) => m.into(),
-            Err(e) => throw_str(&format!("unable to serialize messages: {:?}", e)),
-        }
+        value
+            .serialize(&serializer())
+            .expect_throw("unable to serialize messages")
+            .into()
     }
 }

--- a/crates/dwn-rs-wasm/src/query.rs
+++ b/crates/dwn-rs-wasm/src/query.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 

--- a/crates/dwn-rs-wasm/src/streams/sys.rs
+++ b/crates/dwn-rs-wasm/src/streams/sys.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use js_sys::{AsyncIterator, Function, Iterator, Object};
 use wasm_bindgen::prelude::*;
 use web_sys::AbortSignal;

--- a/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
@@ -10,6 +10,8 @@ use crate::{
     streams::{stream::StreamReadable, sys::Readable},
 };
 
+const READ_CHUNK_SIZE: usize = 512 * 1024;
+
 #[wasm_bindgen(js_name = SurrealDataStore)]
 pub struct SurrealDataStore {
     store: SurrealDB,
@@ -58,9 +60,9 @@ impl SurrealDataStore {
         cid: &str,
         value: Readable,
     ) -> Result<DataStorePutResult, JsValue> {
-        let readable = StreamReadable::new(value).into_stream().map(|r| {
+        let readable = StreamReadable::new(value).into_stream().flat_map(|r| {
             let val = serde_wasm_bindgen::to_value(&r).unwrap();
-            js_sys::Uint8Array::new(&val).to_vec()
+            async_std::stream::from_iter(js_sys::Uint8Array::new(&val).to_vec())
         });
 
         match self
@@ -87,7 +89,10 @@ impl SurrealDataStore {
         };
 
         let size = v.size;
-        let reader = v.data.map(|r| Some(serde_bytes::ByteBuf::from(r)));
+        let reader = v
+            .data
+            .chunks(READ_CHUNK_SIZE)
+            .map(|r| Some(serde_bytes::ByteBuf::from(r)));
 
         let obj: DataStoreGetResult = JsCast::unchecked_into(Object::new());
         Reflect::set(&obj, &"dataSize".into(), &size.into())?;

--- a/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/data_store.rs
@@ -1,4 +1,3 @@
-use alloc::string::ToString;
 use async_stream::stream;
 
 use futures_util::StreamExt;
@@ -68,7 +67,7 @@ impl SurrealDataStore {
 
         match self
             .store
-            .put(tenant, record_id.to_string(), cid.to_string(), readable)
+            .put(tenant, record_id, cid, readable)
             .await
             .map_err(Into::<JsError>::into)
         {
@@ -84,11 +83,7 @@ impl SurrealDataStore {
         record_id: &str,
         cid: &str,
     ) -> Result<Option<DataStoreGetResult>, JsValue> {
-        let mut v = match self
-            .store
-            .get(tenant, record_id.to_string(), cid.to_string())
-            .await
-        {
+        let mut v = match self.store.get(tenant, record_id, cid).await {
             Ok(d) => d,
             Err(_) => return Ok(None),
         };
@@ -135,7 +130,7 @@ impl SurrealDataStore {
         cid: &str,
     ) -> Result<(), JsValue> {
         self.store
-            .delete(tenant, record_id.to_string(), cid.to_string())
+            .delete(tenant, record_id, cid)
             .await
             .map_err(Into::<JsError>::into)?;
 

--- a/crates/dwn-rs-wasm/src/surrealdb/event_log.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/event_log.rs
@@ -1,7 +1,4 @@
-use alloc::{
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::String, vec::Vec};
 use dwn_rs_core::{
     errors::EventLogError,
     filters::{Cursor, QueryReturn},
@@ -61,7 +58,7 @@ impl SurrealEventLog {
     pub async fn append(&self, tenant: &str, cid: &str, indexes: IndexMap) -> Result<(), JsError> {
         let (indexes, tags) = indexes.into();
         self.store
-            .append(tenant, cid.to_string(), indexes, tags)
+            .append(tenant, cid, indexes, tags)
             .await
             .map_err(EventLogError::from)
             .map_err(Into::<JsError>::into)?;

--- a/crates/dwn-rs-wasm/src/surrealdb/event_log.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/event_log.rs
@@ -1,5 +1,9 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use dwn_rs_core::{
-    errors::{EventLogError, StoreError},
+    errors::EventLogError,
     filters::{Cursor, QueryReturn},
     stores::EventLog,
 };
@@ -7,21 +11,10 @@ use dwn_rs_stores::{surrealdb::SurrealDB, SurrealDBError};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 
-use thiserror::Error;
-
 use crate::{
     filter::{Filter, IndexMap},
     query::{JSPaginationCursor, JSQueryReturn},
 };
-
-#[derive(Error, Debug)]
-enum SurrealEventLogError {
-    #[error("Store error: {0}")]
-    StoreError(#[from] StoreError),
-
-    #[error("store connection failed: {0}")]
-    ConnectionFailed(#[from] SurrealDBError),
-}
 
 #[wasm_bindgen(js_name = SurrealEventLog)]
 #[derive(Default)]

--- a/crates/dwn-rs-wasm/src/surrealdb/message_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/message_store.rs
@@ -88,7 +88,7 @@ impl SurrealMessageStore {
     pub async fn get(
         &self,
         tenant: &str,
-        cid: String,
+        cid: &str,
         options: Option<MessageStoreOptions>,
     ) -> Result<GenericMessage, JsValue> {
         check_aborted(options)?;
@@ -148,7 +148,7 @@ impl SurrealMessageStore {
     pub async fn delete(
         &self,
         tenant: &str,
-        cid: String,
+        cid: &str,
         options: Option<MessageStoreOptions>,
     ) -> Result<(), JsValue> {
         check_aborted(options)?;

--- a/crates/dwn-rs-wasm/src/surrealdb/resumable_task_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/resumable_task_store.rs
@@ -1,4 +1,3 @@
-use alloc::{format, string::String};
 use dwn_rs_core::{stores::ResumableTaskStore, Value};
 use dwn_rs_stores::SurrealDB;
 use wasm_bindgen::prelude::*;
@@ -25,7 +24,8 @@ impl SurrealResumableTaskStore {
         self.store
             .connect(connstr)
             .await
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
+            .map_err(JsError::from)
+            .map_err(Into::into)
     }
 
     #[wasm_bindgen]
@@ -33,7 +33,8 @@ impl SurrealResumableTaskStore {
         self.store
             .open()
             .await
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
+            .map_err(JsError::from)
+            .map_err(Into::into)
     }
 
     #[wasm_bindgen]
@@ -65,7 +66,7 @@ impl SurrealResumableTaskStore {
     }
 
     #[wasm_bindgen]
-    pub async fn read(&self, id: String) -> Result<Option<JsManagedResumableTask>, JsValue> {
+    pub async fn read(&self, id: &str) -> Result<Option<JsManagedResumableTask>, JsValue> {
         let t = self
             .store
             .read::<Value>(id)
@@ -80,7 +81,7 @@ impl SurrealResumableTaskStore {
     }
 
     #[wasm_bindgen]
-    pub async fn extend(&self, id: String, timeout: u32) -> Result<(), JsValue> {
+    pub async fn extend(&self, id: &str, timeout: u32) -> Result<(), JsValue> {
         self.store
             .extend(id, timeout as u64)
             .await
@@ -89,7 +90,7 @@ impl SurrealResumableTaskStore {
     }
 
     #[wasm_bindgen]
-    pub async fn delete(&self, id: String) -> Result<(), JsValue> {
+    pub async fn delete(&self, id: &str) -> Result<(), JsValue> {
         self.store
             .delete(id)
             .await

--- a/crates/dwn-rs-wasm/src/surrealdb/resumable_task_store.rs
+++ b/crates/dwn-rs-wasm/src/surrealdb/resumable_task_store.rs
@@ -1,3 +1,4 @@
+use alloc::{format, string::String};
 use dwn_rs_core::{stores::ResumableTaskStore, Value};
 use dwn_rs_stores::SurrealDB;
 use wasm_bindgen::prelude::*;

--- a/crates/dwn-rs-wasm/src/task.rs
+++ b/crates/dwn-rs-wasm/src/task.rs
@@ -1,9 +1,9 @@
 use core::fmt::Debug;
 
-use alloc::{format, vec::Vec};
+use alloc::vec::Vec;
 use dwn_rs_core::{stores::ManagedResumableTask, value::Value};
 use serde::Serialize;
-use wasm_bindgen::{prelude::*, throw_str};
+use wasm_bindgen::prelude::*;
 
 use crate::ser::serializer;
 
@@ -24,10 +24,9 @@ where
     T: Serialize + Sync + Send + Debug,
 {
     fn from(task: ManagedResumableTask<T>) -> Self {
-        match task.serialize(&serializer()) {
-            Ok(t) => t.into(),
-            Err(e) => throw_str(&format!("{:?}", e)),
-        }
+        task.serialize(&serializer())
+            .expect_throw("unable to serialize task")
+            .into()
     }
 }
 
@@ -45,9 +44,9 @@ where
 
 impl From<Vec<ManagedResumableTask<Value>>> for JsManagedResumableTaskArray {
     fn from(tasks: Vec<ManagedResumableTask<Value>>) -> Self {
-        match tasks.serialize(&serializer()) {
-            Ok(t) => t.into(),
-            Err(e) => throw_str(&format!("{:?}", e)),
-        }
+        tasks
+            .serialize(&serializer())
+            .expect_throw("unable to serialize tasks")
+            .into()
     }
 }

--- a/crates/dwn-rs-wasm/src/task.rs
+++ b/crates/dwn-rs-wasm/src/task.rs
@@ -1,5 +1,6 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
+use alloc::{format, vec::Vec};
 use dwn_rs_core::{stores::ManagedResumableTask, value::Value};
 use serde::Serialize;
 use wasm_bindgen::{prelude::*, throw_str};

--- a/crates/dwn-rs-wasm/src/task.rs
+++ b/crates/dwn-rs-wasm/src/task.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::{prelude::*, throw_str};
 use crate::ser::serializer;
 
 #[wasm_bindgen(typescript_custom_section)]
-const TASK_IMPORT: &str = r"import { ManagedResumableTask } from '@tbd54566975/dwn-sdk-js";
+const TASK_IMPORT: &str = r"import { ManagedResumableTask } from '@tbd54566975/dwn-sdk-js';";
 
 #[wasm_bindgen]
 extern "C" {

--- a/crates/dwn-rs-wasm/src/tracing.rs
+++ b/crates/dwn-rs-wasm/src/tracing.rs
@@ -1,18 +1,12 @@
-use std::cell::RefCell;
-
-use wasm_bindgen::prelude::*;
-
-thread_local! {
-    pub static TRACING_LEVEL: RefCell<Option<tracing::Level>> = RefCell::new(None);
-}
+use wasm_bindgen::{prelude::*, throw_str};
 
 #[wasm_bindgen]
 /// Initialize tracing with a console subscriber. This is useful for debugging
 /// in the browser. By default, the subscriber will log all events at the `Error`
 /// level. This can be adjusted by calling `set_tracing_level`, however you must
 /// call this function before any tracing events are emitted.
-pub fn init_tracing() {
-    let level = TRACING_LEVEL.with(|l| l.borrow().unwrap_or(tracing::Level::ERROR));
+pub fn init_tracing(level: TracingLevel) {
+    let level: tracing::Level = level.into();
     tracing_subscriber::fmt()
         .with_max_level(level)
         .with_writer(
@@ -21,12 +15,6 @@ pub fn init_tracing() {
         )
         .without_time()
         .init();
-}
-
-#[wasm_bindgen]
-/// Sets the global traving level. This must be called before the tracing initialization.
-pub fn set_tracing_level(level: TracingLevel) {
-    TRACING_LEVEL.with(|l| *l.borrow_mut() = Some(level.into()));
 }
 
 #[wasm_bindgen]

--- a/crates/dwn-rs-wasm/src/tracing.rs
+++ b/crates/dwn-rs-wasm/src/tracing.rs
@@ -1,4 +1,4 @@
-use wasm_bindgen::{prelude::*, throw_str};
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 /// Initialize tracing with a console subscriber. This is useful for debugging

--- a/crates/dwn-rs-wasm/tests/test.browser.js
+++ b/crates/dwn-rs-wasm/tests/test.browser.js
@@ -4,15 +4,14 @@ import init, {
   SurrealMessageStore,
   SurrealEventLog,
   SurrealResumableTaskStore,
-  init_tracing, set_tracing_level, TracingLevel
+  init_tracing, TracingLevel
 } from "../browsers/index.js";
 import stores from "../browsers/index_bg.wasm";
 
 let instance = await stores();
 await init(instance);
 
-set_tracing_level(TracingLevel.Error);
-init_tracing();
+init_tracing(TracingLevel.Error);
 
 let s = new SurrealMessageStore();
 // await s.connect("ws://192.168.10.56:8000/");

--- a/crates/dwn-rs-wasm/tests/test.js
+++ b/crates/dwn-rs-wasm/tests/test.js
@@ -4,14 +4,13 @@ import {
   SurrealMessageStore,
   SurrealEventLog,
   SurrealResumableTaskStore,
-  init_tracing, set_tracing_level, TracingLevel,
+  init_tracing, TracingLevel,
 } from "../pkg/index.js";
 import WebSocket from "isomorphic-ws";
 
 global.WebSocket = WebSocket;
 
-set_tracing_level(TracingLevel.Error);
-init_tracing();
+init_tracing(TracingLevel.Error);
 
 let s = new SurrealMessageStore();
 await s.connect("mem://");


### PR DESCRIPTION
This PR adds some tests for Protocol definitions, and includes `#![no_std]` on the crate `dwn-rs-wasm`. Additional crates still require work for `#![no_std]`.

This PR also includes an improvement to the DataStream to include bytes as `Stream<Item = u8>` instead of pre-chunks `Stream<Item = Vec<u8>>` to allow more control over the stream process.